### PR TITLE
Install bash to use related commands

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash # exit on error
+sudo apt-get install bash
+
+#!/usr/bin/env bash
+# exit on error
 set -o errexit
 
 bundle install


### PR DESCRIPTION
Seems like Render uses Ubuntu under the hood from here: https://community.render.com/t/what-operating-system-do-render-servers-run/238

Also, this is the post where they suggest setting up bash is the fix: https://community.render.com/t/in-the-shell-script-that-is-run-during-deploy-usr-bin-env-bash-in-the-shell-script-executed-during-deploy-appears-to-cause-an-error/20413